### PR TITLE
Resolves #4 - Clean URLs

### DIFF
--- a/gen/main.cc
+++ b/gen/main.cc
@@ -235,7 +235,11 @@ int main(int argc, char** argv) {
                 versus_file << render_file_with_layout(config.versus_file, vs_conf["title"].as<std::string>());
                 versus_file.close();
 
-                versus_links[pair.first][vs_conf["name"].as<std::string>()] = "versus/" + vs_conf["filename"].as<std::string>();
+                auto filename = vs_conf["filename"].as<std::string>();
+                if (filename.substr(filename.length() - 5) == ".html") {
+                    filename = filename.substr(0, filename.length() - 5);
+                }
+                versus_links[pair.first][vs_conf["name"].as<std::string>()] = "versus/" + filename;
             }
         }
     }


### PR DESCRIPTION
This resolves Issue #4, which is to use clean URLs (remove the .html
exension) for versus pages. This just makes things friendly for humans
and is less distracting when sharing links with people (shorter is also
nicer). Also, it just wasn't necessary given the rack server config I'm
using anyways, so just fully taking advantage of that.