### PR TITLE
Docker Cache Improvements

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,8 +1,13 @@
 FROM ubuntu:18.04
 MAINTAINER John Murray <me@johnmurray.io>
 
+# Define the port the dev-server is going to run on
 EXPOSE 1234
 
+# Install all of our dependencies. This includes deps for:
+#  - Running the site's web-server
+#  - Compiling the site-generator
+#  - Auxillary site-building tools (node/npm)
 RUN apt-get update
 RUN apt-get install -y \
       clang-6.0 \
@@ -18,9 +23,21 @@ RUN apt-get install -y \
 RUN npm install -g less
 RUN gem install bundler
 
+# Setup web-server dependencies
 COPY Gemfile .
 COPY Gemfile.lock .
 RUN bundle install
 
+# Compile Site Generator
+RUN mkdir -p gen
+COPY gen gen/
+COPY Makefile .
+RUN make clean && make compile
+
+# copy site, generate files, start the web-server
+# ---
+# This is the bit that is almost _certainly_ not going to
+# get cached, so anything that is more static or less likely
+# to invalidate the cache should happen before these two lines
 COPY . .
-CMD make clean && make compile && make generate && make serve
+CMD make clean && make generate && make serve


### PR DESCRIPTION
Break up the dockerfile for building the site into more cahceable
components. Now it's much faster to iterate on changes to versues and
does not require an internet connection (previously the rubygem install
bits were not cached). No internet connections should be required _most_
of the time since no package/npm/gem installs will be needed.

Compiling the site-generator is also done before the general
site-generation, which gives a significant speed boost to the
change/build/test cycle.